### PR TITLE
feat: Support for Bedrock models via Converse API

### DIFF
--- a/AlgoPuzzleVQA/README.md
+++ b/AlgoPuzzleVQA/README.md
@@ -68,18 +68,26 @@ python main.py evaluate_multi_choice data/wheel_of_fortune.json --model_name cla
 
 Gemini Pro (multimodal): Please create a file named `gemini_vision_info.json`
 
-```
+```json
 {"engine": "gemini-pro-vision", "key": "your_api_key"}
 ```
 
 GPT-4V (multimodal): Please create a file named `openai_vision_info.json`
 
-```
+```json
 {"engine": "gpt-4-vision-preview", "key": "your_api_key"}
 ```
 
 Claude 3 Opus (multimodal): Please create a file named `claude_info.json`
 
-```
+```json
 {"engine": "claude-3-opus-20240229", "key": "your_api_key"}
+```
+
+Claude 3.5 Sonnet (multimodal) via [Amazon Bedrock](https://aws.amazon.com/bedrock/claude/): Please create a file named `bedrock_info.json`
+
+> 💡 For more information on how to select a default AWS Region and setup AWS credentials, please refer to the [AWS Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) (Developer Guide > Credentials).
+
+```json
+{"engine": "anthropic.claude-3-5-sonnet-20240620-v1:0"}
 ```

--- a/AlgoPuzzleVQA/data_loading.py
+++ b/AlgoPuzzleVQA/data_loading.py
@@ -22,6 +22,13 @@ def convert_image_to_text(image: Image) -> str:
     return base64.b64encode(data).decode("utf-8")
 
 
+def convert_image_to_bytes(image: Image) -> bytes:
+    with io.BytesIO() as output:
+        image.save(output, format="PNG")
+        data = output.getvalue()
+    return data
+
+
 def convert_text_to_image(text: str) -> Image:
     data = base64.b64decode(text.encode("utf-8"))
     return Image.open(io.BytesIO(data))

--- a/AlgoPuzzleVQA/modeling.py
+++ b/AlgoPuzzleVQA/modeling.py
@@ -2,13 +2,15 @@ import json
 import time
 import torch
 import anthropic
+import botocore
+import boto3
 from PIL import Image
 from fire import Fire
 from openai import OpenAI
 from pydantic import BaseModel
 from typing import Optional, List
 import google.generativeai as genai
-from data_loading import convert_image_to_text, load_image
+from data_loading import convert_image_to_text, convert_image_to_bytes, load_image
 from transformers import AutoProcessor, LlavaForConditionalGeneration, LlavaProcessor
 
 
@@ -25,7 +27,6 @@ class EvalModel(BaseModel, arbitrary_types_allowed=True):
         factor = self.max_image_size / max(h, w)
         h = round(h * factor)
         w = round(w * factor)
-        print(dict(old=image.size, resized=(h, w)))
         if image.mode == "RGBA":
             image = image.convert("RGB")
         image = image.resize((h, w), Image.LANCZOS)
@@ -252,12 +253,71 @@ class ClaudeModel(EvalModel):
         return output
 
 
+class BedrockModel(EvalModel):
+    model_path: str = "bedrock_info.json"
+    engine: str = ""
+    client: Optional[botocore.client.BaseClient]
+
+    def load(self):
+        with open(self.model_path) as f:
+            info = json.load(f)
+            self.engine = info["engine"]
+            self.client = boto3.client('bedrock-runtime')
+
+    def make_messages(self, prompt: str, image: Image = None) -> List[dict]:
+        image_media_type = "png"
+        image_data = convert_image_to_bytes(self.resize_image(image))
+
+        inputs = [
+            {
+                "image": {
+                    "format": image_media_type,
+                    "source": {
+                        "bytes": image_data
+                    }
+                },
+            },
+            {
+                "text": prompt
+            },
+        ]
+
+        return [{"role": "user", "content": inputs}]
+
+    def run(self, prompt: str, image: Image = None) -> str:
+        self.load()
+        output = ""
+        error_message = "The response was filtered"
+
+        while not output:
+            try:
+                response = self.client.converse(
+                    modelId=self.engine,
+                    messages=self.make_messages(prompt, image),
+                    inferenceConfig={
+                        "temperature": self.temperature,
+                        "maxTokens": 512
+                    }
+                )
+                output = response['output']['message']['content'][0]['text']
+            except Exception as e:
+                raise e
+                if error_message in str(e):
+                    output = error_message
+
+            if not output:
+                print("BedrockModel request failed, retrying...")
+
+        return output
+
+
 def select_model(model_name: str, **kwargs) -> EvalModel:
     model_map = dict(
         gemini_vision=GeminiVisionModel,
         openai_vision=OpenAIVisionModel,
         llava=LlavaModel,
         claude=ClaudeModel,
+        bedrock=BedrockModel,
     )
     model_class = model_map.get(model_name)
     if model_class is None:

--- a/AlgoPuzzleVQA/requirements.txt
+++ b/AlgoPuzzleVQA/requirements.txt
@@ -17,3 +17,4 @@ Shapely==2.0.3
 num2words==0.5.13
 magiccube==0.2.10
 scipy==1.12.0
+boto3==1.34.140

--- a/PuzzleVQA/README.md
+++ b/PuzzleVQA/README.md
@@ -56,19 +56,20 @@ python data_generation.py create_data <puzzle_name>
 
 ## Model Evaluation
 
-Run zero-shot evaluation with LLMs like [Gemini Pro](https://ai.google.dev/tutorials/python_quickstart?hl=en) or [GPT-4(V)](https://platform.openai.com/docs/guides/vision) or [Claude 3 Opus](https://docs.anthropic.com/claude/docs/vision) 
+Run zero-shot evaluation with LLMs like [Gemini Pro](https://ai.google.dev/tutorials/python_quickstart?hl=en), [GPT-4(V)](https://platform.openai.com/docs/guides/vision) or [Claude 3 Opus](https://docs.anthropic.com/claude/docs/vision) (via Anthropic API or Amazon Bedrock).
 
 ### Example to run evalution on "triangle" puzzle with Gemini Pro 
 ```bash
 python main.py evaluate_multi_choice data/triangle.json \
---model_name gemini_vision \
---prompt_name cot_multi_extract \
+    --model_name gemini_vision \
+    --prompt_name cot_multi_extract
 ```
 
 ### Supported Models
 - `gemini_vision`
 - `openai_vision`
 - `claude`
+- `bedrock`
 
 ### Supported Prompts
 - `cot_multi_extract`
@@ -80,18 +81,26 @@ python main.py evaluate_multi_choice data/triangle.json \
 
 Gemini Pro (multimodal): Please create a file named `gemini_vision_info.json`
 
-```
+```json
 {"engine": "gemini-pro-vision", "key": "your_api_key"}
 ```
 
 GPT-4V (multimodal): Please create a file named `openai_vision_info.json`
 
-```
+```json
 {"engine": "gpt-4-vision-preview", "key": "your_api_key"}
 ```
 
 Claude 3 Opus (multimodal): Please create a file named `claude_info.json`
 
-```
+```json
 {"engine": "claude-3-opus-20240229", "key": "your_api_key"}
+```
+
+Claude 3.5 Sonnet (multimodal) via [Amazon Bedrock](https://aws.amazon.com/bedrock/claude/): Please create a file named `bedrock_info.json`
+
+> 💡 For more information on how to select a default AWS Region and setup AWS credentials, please refer to the [AWS Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) (Developer Guide > Credentials).
+
+```json
+{"engine": "anthropic.claude-3-5-sonnet-20240620-v1:0"}
 ```

--- a/PuzzleVQA/data_loading.py
+++ b/PuzzleVQA/data_loading.py
@@ -21,6 +21,7 @@ def convert_image_to_text(image: Image) -> str:
         data = output.getvalue()
     return base64.b64encode(data).decode("utf-8")
 
+
 def convert_image_to_bytes(image: Image) -> bytes:
     with io.BytesIO() as output:
         image.save(output, format=image.format)

--- a/PuzzleVQA/data_loading.py
+++ b/PuzzleVQA/data_loading.py
@@ -21,6 +21,12 @@ def convert_image_to_text(image: Image) -> str:
         data = output.getvalue()
     return base64.b64encode(data).decode("utf-8")
 
+def convert_image_to_bytes(image: Image) -> bytes:
+    with io.BytesIO() as output:
+        image.save(output, format=image.format)
+        data = output.getvalue()
+    return data
+
 
 def convert_text_to_image(text: str) -> Image:
     data = base64.b64decode(text.encode("utf-8"))

--- a/PuzzleVQA/modeling.py
+++ b/PuzzleVQA/modeling.py
@@ -320,7 +320,7 @@ class BedrockModel(EvalModel):
                     "format": image_media_type,
                     "source": {
                         "bytes": image_data
-					}
+                    }
                 },
             },
             {
@@ -343,7 +343,7 @@ class BedrockModel(EvalModel):
                     inferenceConfig={
                         "temperature": self.temperature,
                         "maxTokens": 512
-					}
+                    }
                 )
                 output = response['output']['message']['content'][0]['text']
             except Exception as e:

--- a/PuzzleVQA/modeling.py
+++ b/PuzzleVQA/modeling.py
@@ -2,13 +2,15 @@ import json
 import time
 import torch
 import anthropic
+import botocore
+import boto3
 from PIL import Image
 from fire import Fire
 from openai import OpenAI
 from pydantic import BaseModel
 from typing import Optional, List
 import google.generativeai as genai
-from data_loading import convert_image_to_text, load_image
+from data_loading import convert_image_to_text, convert_image_to_bytes, load_image
 from transformers import (
     AutoProcessor,
     LlavaForConditionalGeneration,
@@ -297,6 +299,64 @@ class QwenModel(EvalModel):
         return response
 
 
+class BedrockModel(EvalModel):
+    model_path: str = "bedrock_info.json"
+    engine: str = ""
+    client: Optional[botocore.client.BaseClient]
+
+    def load(self):
+        with open(self.model_path) as f:
+            info = json.load(f)
+            self.engine = info["engine"]
+            self.client = boto3.client('bedrock-runtime')
+
+    def make_messages(self, prompt: str, image: Image = None) -> List[dict]:
+        image_media_type = "png"
+        image_data = convert_image_to_bytes(self.resize_image(image))
+
+        inputs = [
+            {
+                "image": {
+                    "format": image_media_type,
+                    "source": {
+                        "bytes": image_data
+					}
+                },
+            },
+            {
+                "text": prompt
+            },
+        ]
+
+        return [{"role": "user", "content": inputs}]
+
+    def run(self, prompt: str, image: Image = None) -> str:
+        self.load()
+        output = ""
+        error_message = "The response was filtered"
+
+        while not output:
+            try:
+                response = self.client.converse(
+                    modelId=self.engine,
+                    messages=self.make_messages(prompt, image),
+                    inferenceConfig={
+                        "temperature": self.temperature,
+                        "maxTokens": 512
+					}
+                )
+                output = response['output']['message']['content'][0]['text']
+            except Exception as e:
+                print(e)
+                if error_message in str(e):
+                    output = error_message
+
+            if not output:
+                print("BedrockModel request failed, retrying...")
+
+        return output
+
+
 def select_model(model_name: str, **kwargs) -> EvalModel:
     model_map = dict(
         gemini_vision=GeminiVisionModel,
@@ -304,6 +364,7 @@ def select_model(model_name: str, **kwargs) -> EvalModel:
         llava=LlavaModel,
         claude=ClaudeModel,
         qwen=QwenModel,
+        bedrock=BedrockModel,
     )
     model_class = model_map.get(model_name)
     if model_class is None:

--- a/PuzzleVQA/requirements.txt
+++ b/PuzzleVQA/requirements.txt
@@ -18,3 +18,4 @@ einops==0.7.0
 transformers_stream_generator==0.0.5
 torchvision==0.17.0
 accelerate==0.28.0
+boto3==1.34.140


### PR DESCRIPTION
**Changes:**
- Added new `BedrockModel` to the list of supported models/providers
- Added data-loading `convert_image_to_bytes` helper function
- Updated PuzzleVQA and AlgoPuzzleVQA docs

#### Example

> 💡 For more information on how to select a default AWS Region and setup AWS credentials, please refer to the [AWS Boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) (Developer Guide > Credentials).

```bash
python main.py \
    evaluate_multi_choice data/color_hexagon.json \
    --model_name bedrock \
    --prompt_name cot_caption_explanation_deduction_multi_extract
```

**bedrock_info.json**

```json
{"engine": "anthropic.claude-3-5-sonnet-20240620-v1:0"}
```